### PR TITLE
Table footer to download table data as CSV and JSON

### DIFF
--- a/example.html
+++ b/example.html
@@ -108,7 +108,8 @@
             autoGenerateColumns:true,
             fixedColumns:fixedColumns,
             columns:columns,
-            items:items
+            items:items,
+            footerPresent:false
            }),
         document.getElementById('fixed_table')
       );

--- a/example.html
+++ b/example.html
@@ -8,6 +8,7 @@
     <!-- js -->
     <script src="https://fb.me/react-0.13.1.js"></script>
     <script src="react_smart_table.js"></script>
+    <script src="https://cdn.rawgit.com/eligrey/FileSaver.js/master/FileSaver.js"></script>
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <!-- Optional theme

--- a/react_smart_table.js
+++ b/react_smart_table.js
@@ -93,6 +93,7 @@ table   [fixed size]
                                   // minus offsetBottom
                 headerHeight:60,  // height of the header
                 rowHeight:30,     // height of a row
+                footerHeight:15,
                 items:[],
                 fixedColumns:[],
                 columns:[],
@@ -440,6 +441,7 @@ table   [fixed size]
             var innerRightWidth = columnsExtents[columnsExtents.length-1];
 
             var headerHeight = this.props.headerHeight;
+            var footerHeight = this.props.footerHeight;
             var innerHeight = rowsExtents[rowsExtents.length-1];
 
             // handle case where height is set by its content
@@ -454,7 +456,7 @@ table   [fixed size]
             var outerRightWidth = width - leftWidth;
 
             var rightHeaderWidth = outerRightWidth;
-            var bodyHeight = height - headerHeight;
+            var bodyHeight = height - headerHeight - footerHeight;
             var leftBodyHeight = bodyHeight;
 
             // account for scrollbar
@@ -562,6 +564,27 @@ table   [fixed size]
                 grids.push(body);
             }
 
+             var footer =
+                    React.DOM.div({
+                        key: "footer",
+                        ref: "footer",
+                        style:{
+                            position: "absolute",
+                            left: 0,
+                            top: headerHeight + bodyHeight,
+                            width: width,
+                            height: footerHeight,
+                            overflowX: "hidden",
+                            backgroundColor:"#EEE",
+                            borderTop: "1px solid #CCC",
+                            fontSize: "10px",
+                            padding: "1px",
+                        }
+                    }, "Download ", React.DOM.a({onClick: this.downloadJSON}, "JSON")
+                );
+
+            grids.push(footer);
+
             var containizer = React.DOM.div({
                 style:{ position:'relative',
                         width:width,
@@ -579,6 +602,10 @@ table   [fixed size]
                 }, containizer);
 
             return table_elem;
+        },
+
+        downloadJSON: function() {
+            alert("plop");
         }
 
     });

--- a/react_smart_table.js
+++ b/react_smart_table.js
@@ -580,7 +580,11 @@ table   [fixed size]
                             fontSize: "10px",
                             padding: "1px",
                         }
-                    }, "Download ", React.DOM.a({onClick: this.downloadJSON}, "JSON")
+                    },
+                    "Download ",
+                    React.DOM.a({onClick: this.downloadJSON, download: "code.json"}, "JSON"),
+                    " - ",
+                    React.DOM.a({onClick: this.downloadCSV, download: "code.csv"}, "CSV")
                 );
 
             grids.push(footer);
@@ -604,8 +608,26 @@ table   [fixed size]
             return table_elem;
         },
 
-        downloadJSON: function() {
-            alert("plop");
+        downloadJSON: function(plop) {
+            var data = this.getFilteredItems();
+            var blob = new Blob([JSON.stringify(data)], {type: "application/json;charset=utf-8"});
+            saveAs(blob, "table_data.json");
+        },
+
+        downloadCSV: function(plop) {
+            var items = this.getFilteredItems();
+            var data = Object.keys(items[0]).join(";") + "\n"; // CSV Header
+
+            for (var row_id in items) {
+                var row = items[row_id];
+                var values = [];
+                for(var key in row) {
+                    values.push(row[key]);
+                }
+                data = data.concat(values.join(";")) + "\n"; // CSV row
+            }
+            var blob = new Blob([data], {type: "application/json;charset=utf-8"});
+            saveAs(blob, "table_data.csv");
         }
 
     });

--- a/react_smart_table.js
+++ b/react_smart_table.js
@@ -94,6 +94,7 @@ table   [fixed size]
                 headerHeight:60,  // height of the header
                 rowHeight:30,     // height of a row
                 footerHeight:15,
+                footerPresent:true,
                 items:[],
                 fixedColumns:[],
                 columns:[],
@@ -441,7 +442,10 @@ table   [fixed size]
             var innerRightWidth = columnsExtents[columnsExtents.length-1];
 
             var headerHeight = this.props.headerHeight;
-            var footerHeight = this.props.footerHeight;
+            if (this.props.footerPresent)
+                var footerHeight = this.props.footerHeight;
+            else
+                var footerHeight = 0;
             var innerHeight = rowsExtents[rowsExtents.length-1];
 
             // handle case where height is set by its content
@@ -564,7 +568,8 @@ table   [fixed size]
                 grids.push(body);
             }
 
-             var footer =
+            if (footerHeight > 0) {
+                var footer =
                     React.DOM.div({
                         key: "footer",
                         ref: "footer",
@@ -586,8 +591,8 @@ table   [fixed size]
                     " - ",
                     React.DOM.a({onClick: this.downloadCSV, download: "code.csv"}, "CSV")
                 );
-
-            grids.push(footer);
+                grids.push(footer);
+            }
 
             var containizer = React.DOM.div({
                 style:{ position:'relative',


### PR DESCRIPTION
This branch adds an optional footer to the table elements in order to download the content of the table as a JSON or CSV file.

I wanted to avoid including `FileSaver.js` but did not find any clean solution. Suggestions are welcome.

Here is an overview of the result so far:
![image](https://cloud.githubusercontent.com/assets/404665/7484746/913a3818-f38c-11e4-9044-009628f84462.png)
